### PR TITLE
Increase intake motor current & current peak for comp

### DIFF
--- a/src/main/include/constants/motors.h
+++ b/src/main/include/constants/motors.h
@@ -200,8 +200,8 @@ namespace motorConfig {
         constexpr static auto neutralMode = ctre::phoenix::motorcontrol::NeutralMode::Brake;
         constexpr static auto voltCompSat = motorConfig::common::voltCompSat;
         constexpr static auto statusFrameMotorMode = argos_lib::status_frame_config::MotorPresetMode::BasicFX;
-        constexpr static auto continuousCurrentLimit = 10_A;
-        constexpr static auto peakCurrentLimit = 20_A;
+        constexpr static auto continuousCurrentLimit = 15_A;
+        constexpr static auto peakCurrentLimit = 25_A;
         constexpr static auto peakCurrentDuration = 1_s;
       };
     }  // namespace intake


### PR DESCRIPTION
Increase the intake motor current in preparation for competition. 
(Tested 4-15-23)